### PR TITLE
syntax (interpolation) changes to support terraform 0.12

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,9 @@
 resource "aws_vpc" "default" {
-  cidr_block           = "${local.cidr_block}"
+  cidr_block           = local.cidr_block
   enable_dns_hostnames = true
   enable_dns_support   = true
 
-  tags {
-    Name = "${var.project}"
+  tags = {
+    Name = var.project
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,11 @@
 output "id" {
-  value = "${aws_vpc.default.id}"
+  value = aws_vpc.default.id
 }
 
 output "default_route_table_id" {
-  value = "${aws_vpc.default.default_route_table_id}"
+  value = aws_vpc.default.default_route_table_id
 }
 
 output "default_security_group_id" {
-  value = "${aws_vpc.default.default_security_group_id}"
+  value = aws_vpc.default.default_security_group_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,8 +11,8 @@ variable "cidr_block" {
 }
 
 locals {
-  project       = "${var.project}"
-  cidr_block    = "${var.cidr_block}"
-  dns_hostnames = "${var.dns_hostnames}"
-  dns_support   = "${var.dns_support}"
+  project       = var.project
+  cidr_block    = var.cidr_block
+  dns_hostnames = var.dns_hostnames
+  dns_support   = var.dns_support
 }


### PR DESCRIPTION
Most of the changes are related only to interpolation syntax (or to avoid errors in _tags_ attributes)